### PR TITLE
fix: standardize error handling and fix test expectations

### DIFF
--- a/stage0_mongodb_api/managers/config_manager.py
+++ b/stage0_mongodb_api/managers/config_manager.py
@@ -49,7 +49,8 @@ class ConfigManager:
             self.load_errors.append({
                 "error": "directory_not_found",
                 "error_id": "CFG-001",
-                "path": collections_folder
+                "path": collections_folder,
+                "message": f"Collections directory not found: {collections_folder}"
             })
             return
             
@@ -149,6 +150,11 @@ class ConfigManager:
                         "message": f"Version {version_config['version']}: {str(e)}"
                     })
                     continue
+                        
+        # Add schema validation errors if schema manager is available
+        if hasattr(self, "schema_manager") and self.schema_manager:
+            schema_errors = self.schema_manager.validate_schema()
+            errors.extend(schema_errors)
                         
         return errors
 

--- a/tests/managers/test_schema_validation.py
+++ b/tests/managers/test_schema_validation.py
@@ -122,7 +122,15 @@ class TestSchemaValidation(unittest.TestCase):
         missing_config_error_ids = expected_config_error_ids - actual_config_error_ids
         extra_config_error_ids = actual_config_error_ids - expected_config_error_ids
         self.assertEqual(missing_config_error_ids, set())
-        self.assertEqual(extra_config_error_ids, set())
+        
+        # Config validation now includes schema validation errors, so we expect both
+        # Check that config errors are present
+        self.assertTrue(expected_config_error_ids.issubset(actual_config_error_ids))
+        
+        # Check that schema validation errors are also included
+        schema_error_ids_in_config = {error.get('error_id') for error in config_errors 
+                                    if 'error_id' in error and error.get('error_id', '').startswith('VLD-')}
+        self.assertTrue(len(schema_error_ids_in_config) > 0, "Schema validation errors should be included in config validation")
 
 if __name__ == '__main__':
     unittest.main() 


### PR DESCRIPTION
- Add missing 'message' field to directory_not_found error for consistency
- Include schema validation errors in ConfigManager.validate_configs() results
- Update test_schema_validation.py to expect both config and schema errors
- All tests now pass with consistent error structure