### PR TITLE
Add default name values for ArrayType items and Dictionary root prope…

### DIFF
--- a/configurator/services/dictionary_services.py
+++ b/configurator/services/dictionary_services.py
@@ -9,7 +9,9 @@ from configurator.services.service_base import ServiceBase
 class Dictionary(ServiceBase):
     def __init__(self, file_name: str = None, document: dict = None):
         super().__init__(file_name, document, Config.get_instance().DICTIONARY_FOLDER)
-        self.root = Property(self._document.get("root", {}))
+        root_data = self._document.get("root", {})
+        root_data = {**root_data, "name": root_data.get("name", "root")}
+        self.root = Property(root_data)
 
     def to_dict(self):
         the_dict = super().to_dict()

--- a/configurator/services/property/array_type.py
+++ b/configurator/services/property/array_type.py
@@ -5,7 +5,9 @@ from .property import Property
 class ArrayType(BaseProperty):
     def __init__(self, data: dict):
         super().__init__(data)
-        self.items = Property(data.get("items", {}))
+        items_data = data.get("items", {})
+        items_data = {**items_data, "name": items_data.get("name", "items")}
+        self.items = Property(items_data)
 
     def to_dict(self):
         the_dict = super().to_dict()

--- a/tests/services/property/test_array_type.py
+++ b/tests/services/property/test_array_type.py
@@ -41,6 +41,35 @@ class TestArrayType(unittest.TestCase):
         self.assertTrue(result["required"])
         self.assertIn("items", result)
 
+    def test_array_type_with_items_missing_name(self):
+        """Test ArrayType initialization with items missing name - should default to 'items'"""
+        data = {
+            "name": "test_prop",
+            "description": "Test description",
+            "type": "array",
+            "required": True,
+            "items": {"type": "string"}  # Missing name
+        }
+        prop = ArrayType(data)
+        self.assertEqual(prop.name, "test_prop")
+        self.assertIsNotNone(prop.items)
+        # The items property should have a default name of "items"
+        self.assertEqual(prop.items.name, "items")
+        self.assertEqual(prop.items.type, "string")
+
+    def test_array_type_with_empty_items(self):
+        """Test ArrayType initialization with empty items dict - should default name to 'items'"""
+        data = {
+            "name": "test_prop",
+            "type": "array",
+            "items": {}  # Empty dict, missing name
+        }
+        prop = ArrayType(data)
+        self.assertEqual(prop.name, "test_prop")
+        self.assertIsNotNone(prop.items)
+        # The items property should have a default name of "items"
+        self.assertEqual(prop.items.name, "items")
+
 
 if __name__ == '__main__':
     unittest.main() 

--- a/tests/services/test_dictionary_service_operations.py
+++ b/tests/services/test_dictionary_service_operations.py
@@ -180,6 +180,47 @@ class TestDictionary(unittest.TestCase):
         # Assert
         mock_file_io.delete_document.assert_called_once()
 
+    def test_init_with_root_missing_name(self):
+        """Test Dictionary initialization with root missing name - should default to 'root'"""
+        # Arrange
+        test_document = {
+            "file_name": "test.yaml",
+            "_locked": False,
+            "root": {
+                "description": "Test dictionary",
+                "type": "object",
+                "properties": []
+            }  # Missing name
+        }
+        
+        # Act
+        dictionary = Dictionary(self.test_file_name, test_document)
+        
+        # Assert
+        self.assertEqual(dictionary.file_name, self.test_file_name)
+        self.assertIsNotNone(dictionary.root)
+        # The root property should have a default name of "root"
+        self.assertEqual(dictionary.root.name, "root")
+        self.assertEqual(dictionary.root.type, "object")
+
+    def test_init_with_empty_root(self):
+        """Test Dictionary initialization with empty root dict - should default name to 'root'"""
+        # Arrange
+        test_document = {
+            "file_name": "test.yaml",
+            "_locked": False,
+            "root": {}  # Empty dict, missing name
+        }
+        
+        # Act
+        dictionary = Dictionary(self.test_file_name, test_document)
+        
+        # Assert
+        self.assertEqual(dictionary.file_name, self.test_file_name)
+        self.assertIsNotNone(dictionary.root)
+        # The root property should have a default name of "root"
+        self.assertEqual(dictionary.root.name, "root")
+
 
 if __name__ == '__main__':
     unittest.main() 


### PR DESCRIPTION
- ArrayType now provides default name 'items' when items property is missing or lacks a name
- Dictionary now provides default name 'root' when root property is missing or lacks a name
- Implemented using efficient dict unpacking pattern: {**data, 'name': data.get('name', default)}
- Added unit tests for both missing name and empty dict scenarios
- Maintains backward compatibility with existing code that includes names

Closes #58 